### PR TITLE
ci: Use Docker image directly to run Make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,12 @@ jobs:
         python footnote_build_info.py
         ls -lhtra
     - name: Compile LaTeX document
-      uses: xu-cheng/latex-action@1.2.1
+      uses: docker://xucheng/texlive-full:latest
       with:
-        root_file: HEPML.tex
-        args: -lualatex -logfilewarnings -halt-on-error
+        entrypoint: /bin/sh
+        args: |
+          -c "\
+          apk --no-cache add make && \
+          make document"
     - name: List directory contents
       run: ls -lhtra

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,10 +33,13 @@ jobs:
       run: |
         python footnote_build_info.py
     - name: Compile LaTeX document
-      uses: xu-cheng/latex-action@1.2.1
+      uses: docker://xucheng/texlive-full:latest
       with:
-        root_file: HEPML.tex
-        args: -lualatex -logfilewarnings -halt-on-error
+        entrypoint: /bin/sh
+        args: |
+          -c "\
+          apk --no-cache add make && \
+          make document"
     - name: Setup docs for deployment
       run: |
         mkdir -p docs/_build/review


### PR DESCRIPTION
In an effort to provide higher fidelity testing to the normal workflow, [use the Docker image for the step instead of a GitHub Action](https://github.com/xu-cheng/latex-action/issues/30#issuecomment-623893988), allowing for the `Makefile` to be used directly.

```
* Use Docker image instead of GitHub Action to allow for Makefile to be used
   - Override the image ENTRYPOINT to install make and run
```