### PR TITLE
fix: Move probing heavy ion collisions to chronological placement

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -1,17 +1,5 @@
 # HEPML Papers
 
-%Added on May 10, 2020
-@article{Chien:2018dfn,
-    author = "Chien, Yang-Ting and Kunnawalkam Elayavalli, Raghav",
-    title = "{Probing heavy ion collisions using quark and gluon jet substructure}",
-    eprint = "1803.03589",
-    archivePrefix = "arXiv",
-    primaryClass = "hep-ph",
-    reportNumber = "MIT-CTP 4947, WSU-HEP 1802, MIT-CTP-4947, WSU-HEP-1802",
-    month = "3",
-    year = "2018"
-}
-
 % May 7, 2020
 @article{collaboration2020dijet,
     title="{Dijet resonance search with weak supervision using 13 TeV pp collisions in the ATLAS detector}",
@@ -2027,6 +2015,18 @@ eprint         = "1805.00020",
 archivePrefix  = "arXiv",
 primaryClass   = "hep-ph",
 SLACcitation   = "%%CITATION = ARXIV:1805.00020;%%"
+}
+
+% March 9, 2018
+@article{Chien:2018dfn,
+    author = "Chien, Yang-Ting and Kunnawalkam Elayavalli, Raghav",
+    title = "{Probing heavy ion collisions using quark and gluon jet substructure}",
+    eprint = "1803.03589",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "MIT-CTP 4947, WSU-HEP 1802, MIT-CTP-4947, WSU-HEP-1802",
+    month = "3",
+    year = "2018"
 }
 
 % December 19, 2017

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -59,7 +59,7 @@ The purpose of this note is to collect references for modern machine learning as
 			\begin{itemize}
 			\item $W/Z$ tagging~\cite{deOliveira:2015xxd,Barnard:2016qma,Louppe:2017ipp,Sirunyan:2020lcu,Chen:2019uar}
 			\item $H\rightarrow b\bar{b}$~\cite{Datta:2019ndh,Lin:2018cin,Moreno:2019neq,Chakraborty:2019imr,Sirunyan:2020lcu}
-			\item quarks and gluons~\cite{ATL-PHYS-PUB-2017-017,Komiske:2016rsd,Cheng:2017rdo,Stoye:DLPS2017,Moreno:2019bmu,Kasieczka:2018lwf,Chien:2018dfn}
+			\item quarks and gluons~\cite{ATL-PHYS-PUB-2017-017,Komiske:2016rsd,Cheng:2017rdo,Stoye:DLPS2017,Chien:2018dfn,Moreno:2019bmu,Kasieczka:2018lwf}
 			\item top quark tagging~\cite{Stoye:DLPS2017,Kasieczka:2019dbj,Chakraborty:2020yfc,Diefenbacher:2019ezd,Butter:2017cot,Kasieczka:2017nvn,Macaluso:2018tck}
 			\item strange jets~\cite{Nakai:2020kuu}
 			\item $b$-tagging~\cite{Sirunyan:2017ezt,Guest:2016iqz,bielkov2020identifying}

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ The purpose of this note is to collect references for modern machine learning as
             * [ Deep learning in color: towards automated quark/gluon](https://arxiv.org/abs/1612.01551)
             * [ Recursive Neural Networks in Quark/Gluon Tagging](https://arxiv.org/abs/1711.02633)
             *  DeepJet: Generic physics object based jet multiclass classification for LHC experiments
+            * [ Probing heavy ion collisions using quark and gluon jet substructure](https://arxiv.org/abs/1803.03589)
             * [ JEDI-net: a jet identification algorithm based on interaction networks](https://arxiv.org/abs/1908.05318)
             * [ Quark-Gluon Tagging: Machine Learning vs Detector](https://arxiv.org/abs/1812.09223)
-            * [ Probing heavy ion collisions using quark and gluon jet substructure](https://arxiv.org/abs/1803.03589)
 
         *  top quark tagging
 


### PR DESCRIPTION
Move [Probing heavy ion collisions using quark and gluon jet substructure](https://inspirehep.net/literature/1659306) by Yang-Ting Chien and @rkunnawa to its chronological position given publication date on INSPIRE of 2018-03-09.
