### PR TITLE
chore: Migrate all of HEPML-Resources BibTeX file

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -71,6 +71,17 @@
     year = "2020"
 }
 
+% April 21, 2020
+@article{Romao:2020ojy,
+    author = "Romao, M. Crispim and Castro, N.F. and Milhano, J.G. and Pedro, R. and Vale, T.",
+    archivePrefix = "arXiv",
+    eprint = "2004.09360",
+    month = "4",
+    primaryClass = "hep-ph",
+    title = "{Use of a Generalized Energy Mover's Distance in the Search for Rare Phenomena at Colliders}",
+    year = "2020"
+}
+
 % Added many on April 20, 2020
 @article{Dolen:2016kst,
       author         = "Dolen, James and Harris, Philip and Marzani, Simone and

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -28,7 +28,7 @@
 
 
 \abstract{
-Modern machine learning techniques, including deep learning, is rapidly being applied, adapted, and developed for high energy physics.  The goal of this document is to provide a nearly comprehensive list of citations for those developing and applying these approaches to experimental, phenomenological, or theoretical analyses.  As a living document, it will be updated as often as possible to incorporate the latest developments.  A list of proper (unchanging) reviews can be found within.  Papers are grouped into a small set of topics to be as useful as possible.  Suggestions are most welcome.  
+Modern machine learning techniques, including deep learning, is rapidly being applied, adapted, and developed for high energy physics.  The goal of this document is to provide a nearly comprehensive list of citations for those developing and applying these approaches to experimental, phenomenological, or theoretical analyses.  As a living document, it will be updated as often as possible to incorporate the latest developments.  A list of proper (unchanging) reviews can be found within.  Papers are grouped into a small set of topics to be as useful as possible.  Suggestions are most welcome.
 }
 
 \begin{document}
@@ -42,7 +42,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\item Modern reviews~\cite{Larkoski:2017jix,Guest:2018yhq,Albertsson:2018maf,Radovic:2018dip,Carleo:2019ptp,Kasieczka:2019dbj,Bourilkov:2019yoi}
 		 \item Classical papers~\cite{Denby:1987rk,Lonnblad:1990bi}
 	\end{itemize}
-\item Classification.  
+\item Classification.
 	\begin{itemize}
 		\item Parameterized classifiers~\cite{Baldi:2016fzo,Cranmer:2015bka}.
 		\item Representations
@@ -97,14 +97,14 @@ The purpose of this note is to collect references for modern machine learning as
 		\item Phase space generation~\cite{Bendavid:2017zhk,Bothmann:2020ywa,Gao:2020zvv,Gao:2020vdv,Klimek:2018mza,Carrazza:2020rdn}
 		\item Gaussian processes~\cite{Frate:2017mai,Bertone:2016mdy}
 	\end{itemize}
-\item Anomaly detection~\cite{DAgnolo:2018cun,Collins:2018epr,Collins:2019jip,DAgnolo:2019vbw,Farina:2018fyg,Heimel:2018mkt,Roy:2019jae,Cerri:2018anq,Blance:2019ibf,Hajer:2018kqm,DeSimone:2018efk,Mullin:2019mmh,1809.02977,Dillon:2019cqt,Andreassen:2020nkr,Aguilar-Saavedra:2017rzt,Romao:2019dvs,knapp2020adversarially,collaboration2020dijet}
+\item Anomaly detection~\cite{DAgnolo:2018cun,Collins:2018epr,Collins:2019jip,DAgnolo:2019vbw,Farina:2018fyg,Heimel:2018mkt,Roy:2019jae,Cerri:2018anq,Blance:2019ibf,Hajer:2018kqm,DeSimone:2018efk,Mullin:2019mmh,1809.02977,Dillon:2019cqt,Andreassen:2020nkr,Aguilar-Saavedra:2017rzt,Romao:2019dvs,Romao:2020ojy,knapp2020adversarially,collaboration2020dijet}
 \item Simulation-based (`likelihood-free') Inference.
 	\begin{itemize}
 		\item Overview~\cite{Cranmer:2019eaq}
 		\item Parameter estimation~\cite{Andreassen:2019nnm,Stoye:2018ovl,Hollingsworth:2020kjg,Brehmer:2018kdj,Brehmer:2018eca,Brehmer:2019xox,Brehmer:2018hga,Cranmer:2015bka}
 		\item Unfolding~\cite{Andreassen:2019cjw,Datta:2018mwd,Bellagente:2019uyp,Gagunashvili:2010zw,Glazov:2017vni,Martschei:2012pr,Lindemann:1995ut,Zech2003BinningFreeUB}
 		\item Domain adaptation~\cite{Rogozhnikov:2016bdp,Andreassen:2019nnm,Cranmer:2015bka}
-		\item BSM~\cite{Andreassen:2020nkr,Hollingsworth:2020kjg,Brehmer:2018kdj,Brehmer:2018eca,Brehmer:2018hga,Brehmer:2019xox}
+		\item BSM~\cite{Andreassen:2020nkr,Hollingsworth:2020kjg,Brehmer:2018kdj,Brehmer:2018eca,Brehmer:2018hga,Brehmer:2019xox,Romao:2020ojy}
 	\end{itemize}
 \item Uncertainty Quantification.
 	\begin{itemize}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The purpose of this note is to collect references for modern machine learning as
         *  Neural Networks and Cellular Automata in Experimental High-energy Physics
         *  Finding Gluon Jets With a Neural Trigger
 
-*  Classification.  
+*  Classification.
 
     *  Parameterized classifiers
 
@@ -328,6 +328,7 @@ The purpose of this note is to collect references for modern machine learning as
     * [ Simulation Assisted Likelihood-free Anomaly Detection](https://arxiv.org/abs/2001.05001)
     * [ A generic anti-QCD jet tagger](https://arxiv.org/abs/1709.01087)
     * [ Transferability of Deep Learning Models in Searches for New Physics at Colliders](https://arxiv.org/abs/1912.04220)
+    * [ Use of a Generalized Energy Mover's Distance in the Search for Rare Phenomena at Colliders](https://arxiv.org/abs/2004.09360)
     * [Adversarially Learned Anomaly Detection on CMS Open Data: re-discovering the top quark](https://arxiv.org/abs/2005.01598)
     * [Dijet resonance search with weak supervision using 13 TeV pp collisions in the ATLAS detector](https://arxiv.org/abs/2005.02983)
 
@@ -373,6 +374,7 @@ The purpose of this note is to collect references for modern machine learning as
         * [ A Guide to Constraining Effective Field Theories with Machine Learning](https://arxiv.org/abs/1805.00020)
         * [ Mining gold from implicit models to improve likelihood-free inference](https://arxiv.org/abs/1805.12244)
         * [ MadMiner: Machine learning-based inference for particle physics](https://arxiv.org/abs/1907.10621)
+        * [ Use of a Generalized Energy Mover's Distance in the Search for Rare Phenomena at Colliders](https://arxiv.org/abs/2004.09360)
 
 *  Uncertainty Quantification.
 


### PR DESCRIPTION
- Resolves #13
- Resolves #11 

Synchronize BibTeX file with the state of HEPML-Resources BibTeX file (at https://github.com/iml-wg/HEP-ML-Resources/commit/226ed83ba0654d2a628f9b67e3f13bf627c74847). This effectively is just moving over https://github.com/iml-wg/HEP-ML-Resources/pull/75: "[Use of a Generalized Energy Mover’s Distance in the Search for Rare Phenomena at Colliders](https://inspirehep.net/literature/1791839) by M. C. Romao, @nfcastro, J. Milhano, R. Pedro, and T. Vale

```
* Migrate HEPML-Resources BibTeX file
* Remove trailing whitespace
```