### PR TITLE
feat: Add DOI for Identification of heavy, energetic, hadronically decaying particles paper

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -1639,13 +1639,17 @@
 }
 @article{Sirunyan:2020lcu,
     author = "Sirunyan, Albert M and others",
-    archivePrefix = "arXiv",
     collaboration = "CMS",
-    eprint = "2004.08262",
-    month = "4",
-    primaryClass = "hep-ex",
-    reportNumber = "CMS-JME-18-002, CERN-EP-2020-037",
     title = "{Identification of heavy, energetic, hadronically decaying particles using machine-learning techniques}",
+    eprint = "2004.08262",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "FERMILAB-PUB-20-191-CMS, CMS-JME-18-002, CERN-EP-2020-037",
+    doi = "10.1088/1748-0221/15/06/P06005",
+    journal = "JINST",
+    volume = "15",
+    number = "06",
+    pages = "P06005",
     year = "2020"
 }
 @article{Diefenbacher:2019ezd,

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [ Jet-images — deep learning edition](https://arxiv.org/abs/1511.05190) [[DOI](https://doi.org/10.1007/JHEP07(2016)069)]
             * [ Parton Shower Uncertainties in Jet Substructure Analyses with Deep Neural Networks](https://arxiv.org/abs/1609.00607) [[DOI](https://doi.org/10.1103/PhysRevD.95.014018)]
             * [ QCD-Aware Recursive Neural Networks for Jet Physics](https://arxiv.org/abs/1702.00748)
-            * [ Identification of heavy, energetic, hadronically decaying particles using machine-learning techniques](https://arxiv.org/abs/2004.08262)
+            * [ Identification of heavy, energetic, hadronically decaying particles using machine-learning techniques](https://arxiv.org/abs/2004.08262) [[DOI](https://doi.org/10.1088/1748-0221/15/06/P06005)]
             * [ Boosted $W$ and $Z$ tagging with jet charge and deep learning](https://arxiv.org/abs/1908.08256) [[DOI](https://doi.org/10.1103/PhysRevD.101.053001)]
 
         *  $H\rightarrow b\bar{b}$
@@ -99,7 +99,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [ Boosting $H\to b\bar b$ with Machine Learning](https://arxiv.org/abs/1807.10768) [[DOI](https://doi.org/10.1007/JHEP10(2018)101)]
             * [ Interaction networks for the identification of boosted $H\to b\overline{b}$ decays](https://arxiv.org/abs/1909.12285)
             * [ Interpretable deep learning for two-prong jet classification with jet spectra](https://arxiv.org/abs/1904.02092) [[DOI](https://doi.org/10.1007/JHEP07(2019)135)]
-            * [ Identification of heavy, energetic, hadronically decaying particles using machine-learning techniques](https://arxiv.org/abs/2004.08262)
+            * [ Identification of heavy, energetic, hadronically decaying particles using machine-learning techniques](https://arxiv.org/abs/2004.08262) [[DOI](https://doi.org/10.1088/1748-0221/15/06/P06005)]
 
         *  quarks and gluons
 


### PR DESCRIPTION
Add DOI to BibTeX entry for [_Identification of heavy, energetic, hadronically decaying particles using machine-learning techniques_](https://inspirehep.net/literature/1791648) CMS paper.

this does not change the readme unless #22 is merged with displaying the doi