### PR TITLE
paper: Add CMS ggHbb paper with deep double-b tagger

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -11,6 +11,19 @@
     year = "2020"
 }
 
+%June 23
+@article{Sirunyan:2020hwz,
+    author = "Sirunyan, Albert M and others",
+    collaboration = "CMS",
+    title = "{Inclusive search for highly boosted Higgs bosons decaying to bottom quark-antiquark pairs in proton-proton collisions at $\sqrt{s} = 13$ TeV}",
+    eprint = "2006.13251",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ex",
+    reportNumber = "CMS-HIG-19-003, CERN-EP-2020-107",
+    month = "6",
+    year = "2020"
+}
+
 %June 16
 @article{1801423,
     author = "Bernreuther, Elias and Finke, Thorben and Kahlhoefer, Felix and Kr{\"a}mer, Michael and M{\"u}ck, Alexander",

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -116,7 +116,7 @@ The purpose of this note is to collect references for modern machine learning as
 	\end{itemize}
 \item Experimental results. \textit{This section is incomplete as there are many results that directly and indirectly (e.g. via flavor tagging) use modern machine learning techniques.  We will try to highlight experimental results that use deep learning in a critical way for the final analysis sensitivity.}
 	\begin{itemize}
-		\item Final analysis discriminate for searches~\cite{Aad:2019yxi,Aad:2020hzm,collaboration2020dijet}.
+		\item Final analysis discriminate for searches~\cite{Aad:2019yxi,Aad:2020hzm,collaboration2020dijet,Sirunyan:2020hwz}.
 	\end{itemize}
 
 

--- a/README.md
+++ b/README.md
@@ -432,4 +432,5 @@ The purpose of this note is to collect references for modern machine learning as
         * [ Search for non-resonant Higgs boson pair production in the $bb\ell\nu\ell\nu$ final state with the ATLAS detector in $pp$ collisions at $\sqrt{s} ](https://arxiv.org/abs/1908.06765) [[DOI](https://doi.org/10.1016/j.physletb.2019.135145)]
         * [ Search for Higgs boson decays into a $Z$ boson and a light hadronically decaying resonance using 13 TeV $pp$ collision data from the ATLAS detector](https://arxiv.org/abs/2004.01678)
         * [Dijet resonance search with weak supervision using 13 TeV pp collisions in the ATLAS detector](https://arxiv.org/abs/2005.02983)
+        * [ Inclusive search for highly boosted Higgs bosons decaying to bottom quark-antiquark pairs in proton-proton collisions at $\sqrt{s} ](https://arxiv.org/abs/2006.13251)
 


### PR DESCRIPTION
- add CMS ggHbb which uses the deep double-b tagger