### PR TITLE
revert: Remove ML only paper

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -1,16 +1,5 @@
 # HEPML Papers
 
-% 2015-06-07
-@article{chung2016recurrent,
-      title="{A Recurrent Latent Variable Model for Sequential Data}",
-      author="Junyoung Chung and Kyle Kastner and Laurent Dinh and Kratarth Goel and Aaron Courville and Yoshua Bengio",
-      eprint="1506.02216",
-      archivePrefix="arXiv",
-      primaryClass="cs.LG",
-      month="4",
-      year="2016"
-}
-
 %September 10
 
 @article{1816035,

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -102,7 +102,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\item Phase space generation~\cite{Bendavid:2017zhk,Bothmann:2020ywa,Gao:2020zvv,Gao:2020vdv,Klimek:2018mza,Carrazza:2020rdn,Nachman:2020fff}
 		\item Gaussian processes~\cite{Frate:2017mai,Bertone:2016mdy,1804325}
 	\end{itemize}
-\item Anomaly detection~\cite{DAgnolo:2018cun,Collins:2018epr,Collins:2019jip,DAgnolo:2019vbw,Farina:2018fyg,Heimel:2018mkt,Roy:2019jae,Cerri:2018anq,Blance:2019ibf,Hajer:2018kqm,DeSimone:2018efk,Mullin:2019mmh,1809.02977,Dillon:2019cqt,Andreassen:2020nkr,Nachman:2020lpy,Aguilar-Saavedra:2017rzt,Romao:2019dvs,Romao:2020ojy,knapp2020adversarially,collaboration2020dijet,1797846,1800445,Amram:2020ykb,Cheng:2020dal,Khosa:2020qrz,Thaprasop:2020mzp,Alexander:2020mbx,aguilarsaavedra2020mass,1815227,chung2016recurrent}
+\item Anomaly detection~\cite{DAgnolo:2018cun,Collins:2018epr,Collins:2019jip,DAgnolo:2019vbw,Farina:2018fyg,Heimel:2018mkt,Roy:2019jae,Cerri:2018anq,Blance:2019ibf,Hajer:2018kqm,DeSimone:2018efk,Mullin:2019mmh,1809.02977,Dillon:2019cqt,Andreassen:2020nkr,Nachman:2020lpy,Aguilar-Saavedra:2017rzt,Romao:2019dvs,Romao:2020ojy,knapp2020adversarially,collaboration2020dijet,1797846,1800445,Amram:2020ykb,Cheng:2020dal,Khosa:2020qrz,Thaprasop:2020mzp,Alexander:2020mbx,aguilarsaavedra2020mass,1815227}
 \item Simulation-based (`likelihood-free') Inference.
 	\begin{itemize}
 		\item Overview~\cite{Cranmer:2019eaq}

--- a/README.md
+++ b/README.md
@@ -425,7 +425,6 @@ The purpose of this note is to collect references for modern machine learning as
     * [ Decoding Dark Matter Substructure without Supervision](https://arxiv.org/abs/2008.12731)
     * [Mass Unspecific Supervised Tagging (MUST) for boosted jets](https://arxiv.org/abs/2008.12792)
     * [ Simulation-Assisted Decorrelation for Resonant Anomaly Detection](https://arxiv.org/abs/2009.02205)
-    * [A Recurrent Latent Variable Model for Sequential Data](https://arxiv.org/abs/1506.02216)
 
 *  Simulation-based (`likelihood-free') Inference.
 


### PR DESCRIPTION
Revert PR #31. This was my fault for not doing a better review to check the content of the paper before accepting it.

Contributions are helpful and welcome, but the goal of the project is to provide an updating list of references of "modern machine learning as applied to particle physics."

```
* Remove ML only paper with no physics tie in
* Revert PR #31
```