### PR TITLE
docs: Add forking to PR workflow instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ We welcome and encourage contributions of papers that cover modern machine learn
 
 All paper additions should be submitted as a single pull request on a source branch that isn't `master`.
 
-1. Make a new branch for the pull request
+1. Make a new branch on your fork for the pull request
 2. Find the paper on [INSPIRE](https://inspirehep.net/?ln=en)
    - **N.B.:** If you have already found the paper on [arXiv](https://arxiv.org/) you should be able to find the INSPIRE listing linked under "References & Citations"
 3. Get the BibTeX for the paper citation provided by INSPIRE (under "Export" at the bottom of the page)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,12 @@ Before you open an Issue please search through both the closed and open Issues t
 
 ## Pull Request Process
 
-1. Create your Pull Request (PR) (see the FAQ below).
-2. Verify that you have run `make_md.py` to update the `README`.
-3. Ensure that the tests in the CI are passing.
-4. Request that a maintainer review your PR.
-5. Your PR can be merged in once you have the sign-off of at least one maintainer. If you do not have permission to make the merge, request the approving maintainer to merge it for you.
+1. Create a [fork of the project](https://docs.github.com/en/free-pro-team@latest/github/getting-started-with-github/fork-a-repo).
+2. Create your Pull Request (PR) from your fork (see the FAQ below).
+3. Verify that you have run `make_md.py` to update the `README`.
+4. Ensure that the tests in the CI are passing.
+5. Request that a maintainer review your PR.
+6. Your PR can be merged in once you have the sign-off of at least one maintainer. If you do not have permission to make the merge, request the approving maintainer to merge it for you.
 
 ## Areas of Requested Help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,12 @@ If there is content missing that you'd like added please create an issue with as
 A maintainer will add the content once it has been approved.
 Alternatively, feel free to fork the repository and add the content you want and then create a pull request.
 
+### Should I add papers that are only about machine learning?
+
+No.
+While the ML papers that have inspired the work of the particle physics community are invaluable, trying to keep an updated list of all of them would be both beyond the scope of the project and unmaintainable.
+We welcome and encourage contributions of papers that cover modern machine learning applications to particle physics!
+
 ### How do I add a paper?
 
 All paper additions should be submitted as a single pull request on a source branch that isn't `master`.


### PR DESCRIPTION
Update the `CONTRIBUTING.md` thanks to some very helpful discussion with @juliagonski.

```
* Add forking step to PR workflow instructions
* Add FAQ on scope of papers in review
```