### PR TITLE
test: Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.4
+    hooks:
+    - id: pyupgrade
+      args: ["--py37-plus"]

--- a/footnote_build_info.py
+++ b/footnote_build_info.py
@@ -70,7 +70,7 @@ def main():
     patch = make_patch()
 
     copyfile("jheppub.sty", "jheppub.sty.bak")
-    with open("jheppub.sty.bak", "r") as read_file, open(
+    with open("jheppub.sty.bak") as read_file, open(
         "jheppub.sty", "w+"
     ) as write_file:
         for line in read_file:

--- a/make_md.py
+++ b/make_md.py
@@ -56,7 +56,7 @@ def convert_from_bib(myline):
     if "eprint" in myentry_dict:
         paper=""
         if "doi" in myentry_dict:
-            paper=" [[DOI](https://doi.org/{0})]".format( myentry_dict["doi"] )
+            paper=" [[DOI](https://doi.org/{})]".format( myentry_dict["doi"] )
         return "["+myentry_dict["title"]+"](https://arxiv.org/abs/"+myentry_dict["eprint"]+")"+paper
     elif "doi" in myentry_dict:
         return "["+myentry_dict["title"]+"](https://doi.org/"+myentry_dict["doi"]+")"
@@ -90,12 +90,12 @@ for line in myfile:
                 hascites = len(line.split("cite"))
                 if (hascites==1):
                     if "Experimental" not in line:
-                        myfile_out.write("* "+line.replace("\item","")+"\n")
+                        myfile_out.write("* "+line.replace(r"\item","")+"\n")
                     else:
                         myfile_out.write("*  Experimental results. *This section is incomplete as there are many results that directly and indirectly (e.g. via flavor tagging) use modern machine learning techniques.  We will try to highlight experimental results that use deep learning in a critical way for the final analysis sensitivity.*\n\n")
                 else:
-                    myfile_out.write("* "+line.replace("\item","").split("~\cite")[0]+".\n\n")
-                    mycites = line.split("~\cite{")[1].split("}")[0].split(",")
+                    myfile_out.write("* "+line.replace(r"\item","").split(r"~\cite")[0]+".\n\n")
+                    mycites = line.split(r"~\cite{")[1].split("}")[0].split(",")
                     for cite in mycites:
                         myfile_out.write("    * "+convert_from_bib(cite)+"\n")
                         pass
@@ -108,15 +108,15 @@ for line in myfile:
                      mybuffer+="    "
                      pass
                 if (":~" in line):
-                    myfile_out.write(mybuffer+"* "+line.split("~\cite{")[0].split("\item")[1]+"\n\n")
-                    mycites = line.split("~\cite{")[1].replace("}","").split(",")
+                    myfile_out.write(mybuffer+"* "+line.split(r"~\cite{")[0].split(r"\item")[1]+"\n\n")
+                    mycites = line.split(r"~\cite{")[1].replace("}","").split(",")
                     for cite in mycites:
                         myfile_out.write(mybuffer+"    * "+convert_from_bib(cite)+"\n")
                         pass
                     myfile_out.write("\n")
                 else:
-                    myfile_out.write(mybuffer+"* "+line.split("~\cite{")[0].split("\item")[1]+"\n\n")
-                    mycites = line.split("~\cite{")[1].split("}")[0].split(",")
+                    myfile_out.write(mybuffer+"* "+line.split(r"~\cite{")[0].split(r"\item")[1]+"\n\n")
+                    mycites = line.split(r"~\cite{")[1].split("}")[0].split(",")
                     for cite in mycites:
                         myfile_out.write(mybuffer+"    * "+convert_from_bib(cite)+"\n")
                         pass

--- a/make_md.py
+++ b/make_md.py
@@ -56,7 +56,7 @@ def convert_from_bib(myline):
     if "eprint" in myentry_dict:
         paper=""
         if "doi" in myentry_dict:
-            paper=" [[DOI](https://doi.org/{})]".format( myentry_dict["doi"] )
+            paper=f" [[DOI](https://doi.org/{myentry_dict['doi']})]"
         return "["+myentry_dict["title"]+"](https://arxiv.org/abs/"+myentry_dict["eprint"]+")"+paper
     elif "doi" in myentry_dict:
         return "["+myentry_dict["title"]+"](https://doi.org/"+myentry_dict["doi"]+")"


### PR DESCRIPTION
To leverage existing maintenance infrastructure (that has been used extensively in Scikit-HEP) add pre-commit hooks defined in `.pre-commit-config.yaml` that run `pyupgrade` on the Python files changed in a commit if a `pre-commit` installation is found in the environment.

Additionally [activate pre-commit.ci](https://results.pre-commit.ci/repo/github/258003247) to run pre-commit on every PR and automatically pushback changes if needed.

```
* Add pyupgrade as pre-commit hook
   - Runs if if pre-commit is installed in environment
* Apply pre-commit.ci to automatically help maintain code compliance with modern Python 3
* Apply pyupgrade --py37-plus to codebase
```