### PR TITLE
ci: Use texlive-action GitHub Action over texlive-full Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/CD
+name: CI
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7' ]
+        python-version: [ '3.8' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,10 @@ jobs:
         python footnote_build_info.py
         ls -lhtra
     - name: Compile LaTeX document
-      uses: docker://xucheng/texlive-full:latest
+      uses: xu-cheng/texlive-action/full@v1
       with:
-        entrypoint: /bin/sh
-        args: |
-          -c "\
-          apk --no-cache add make && \
-          make document"
+        run: |
+          apk add make
+          make document
     - name: List directory contents
       run: ls -lhtra

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,13 +33,11 @@ jobs:
       run: |
         python footnote_build_info.py
     - name: Compile LaTeX document
-      uses: docker://xucheng/texlive-full:latest
+      uses: xu-cheng/texlive-action/full@v1
       with:
-        entrypoint: /bin/sh
-        args: |
-          -c "\
-          apk --no-cache add make && \
-          make document"
+        run: |
+          apk add make
+          make document
     - name: Setup docs for deployment
       run: |
         mkdir -p docs/_build/review

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.7' ]
+        python-version: [ '3.8' ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Use the [texlive-action GitHub Action](https://github.com/xu-cheng/texlive-action) over the [`xucheng/texlive-full` Docker image](https://github.com/xu-cheng/latex-docker).

```
* Use xu-cheng/texlive-action v1 over xucheng/texlive-full Docker image
* Update Python runtime to Python 3.8
* Update CI workflow name
```