### PR TITLE
fix: Quote title and eprint BibTex fields in .bib file

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -2,15 +2,16 @@
 
 % January 28, 2021
 @misc{gonzalez2021tackling,
-      title={Tackling the muon identification in water Cherenkov detectors problem for the future Southern Wide-field Gamma-ray Observatory by means of Machine Learning}, 
+      title="{Tackling the muon identification in water Cherenkov detectors problem for the future Southern Wide-field Gamma-ray Observatory by means of Machine Learning}",
       author={B. S. Gonz\'{a}lez and R. Concei\c{c}\~{a}o and M. Pimenta and B. Tom\'{e} and A. Guill\'{e}n},
       year={2021},
       eprint={2101.11924},
       archivePrefix={arXiv},
       primaryClass={physics.ins-det}
 }
+
 @misc{goto2021development,
-      title={Development of a Vertex Finding Algorithm using Recurrent Neural Network}, 
+      title="{Development of a Vertex Finding Algorithm using Recurrent Neural Network}",
       author={Kiichi Goto and Taikan Suehara and Tamaki Yoshioka and Masakazu Kurata and Hajime Nagahara and Yuta Nakashima and Noriko Takemura and Masako Iwasaki},
       year={2021},
       eprint={2101.11906},
@@ -20,7 +21,7 @@
 
 % January 27, 2021
 @misc{abbasi2021convolutional,
-      title={A Convolutional Neural Network based Cascade Reconstruction for the IceCube Neutrino Observatory}, 
+      title="{A Convolutional Neural Network based Cascade Reconstruction for the IceCube Neutrino Observatory}",
       author={R. Abbasi and others},
       collaboration="IceCube",
       year={2021},
@@ -31,7 +32,7 @@
 
 % January 25, 2021
 @misc{huang2021convolutionalneuralnetwork,
-      title={A convolutional-neural-network estimator of CMB constraints on dark matter energy injection}, 
+      title="{A convolutional-neural-network estimator of CMB constraints on dark matter energy injection}",
       author={Wei-Chih Huang and Jui-Lin Kuo and Yue-Lin Sming Tsai},
       year={2021},
       eprint={2101.10360},

--- a/HEPML.bib
+++ b/HEPML.bib
@@ -5,7 +5,7 @@
       title="{Tackling the muon identification in water Cherenkov detectors problem for the future Southern Wide-field Gamma-ray Observatory by means of Machine Learning}",
       author={B. S. Gonz\'{a}lez and R. Concei\c{c}\~{a}o and M. Pimenta and B. Tom\'{e} and A. Guill\'{e}n},
       year={2021},
-      eprint={2101.11924},
+      eprint="{2101.11924}",
       archivePrefix={arXiv},
       primaryClass={physics.ins-det}
 }
@@ -14,7 +14,7 @@
       title="{Development of a Vertex Finding Algorithm using Recurrent Neural Network}",
       author={Kiichi Goto and Taikan Suehara and Tamaki Yoshioka and Masakazu Kurata and Hajime Nagahara and Yuta Nakashima and Noriko Takemura and Masako Iwasaki},
       year={2021},
-      eprint={2101.11906},
+      eprint="{2101.11906}",
       archivePrefix={arXiv},
       primaryClass={physics.data-an}
 }
@@ -25,7 +25,7 @@
       author={R. Abbasi and others},
       collaboration="IceCube",
       year={2021},
-      eprint={2101.11589},
+      eprint="{2101.11589}",
       archivePrefix={arXiv},
       primaryClass={hep-ex}
 }
@@ -35,7 +35,7 @@
       title="{A convolutional-neural-network estimator of CMB constraints on dark matter energy injection}",
       author={Wei-Chih Huang and Jui-Lin Kuo and Yue-Lin Sming Tsai},
       year={2021},
-      eprint={2101.10360},
+      eprint="{2101.10360}",
       archivePrefix={arXiv},
       primaryClass={astro-ph.CO}
 }

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [Jet Flavor Classification in High-Energy Physics with Deep Neural Networks](https://arxiv.org/abs/1607.08633) [[DOI](https://doi.org/10.1103/PhysRevD.94.112002)]
             * [Topology classification with deep learning to improve real-time event selection at the LHC](https://arxiv.org/abs/1807.00083) [[DOI](https://doi.org/10.1007/s41781-019-0028-1)]
             * [Jet Flavour Classification Using DeepJet](https://arxiv.org/abs/2008.10519)
-            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/{2101.11906)
+            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/2101.11906)
 
         *  Trees
 
@@ -235,7 +235,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [Semantic Segmentation with a Sparse Convolutional Neural Network for Event Reconstruction in MicroBooNE](https://arxiv.org/abs/2012.08513)
             * [Quantum Convolutional Neural Networks for High Energy Physics Data Analysis](https://arxiv.org/abs/2012.12177)
             * [Vertex and Energy Reconstruction in JUNO with Machine Learning Methods](https://arxiv.org/abs/2101.04839)
-            * [A Convolutional Neural Network based Cascade Reconstruction for the IceCube Neutrino Observatory](https://arxiv.org/abs/{2101.11589)
+            * [A Convolutional Neural Network based Cascade Reconstruction for the IceCube Neutrino Observatory](https://arxiv.org/abs/2101.11589)
 
         *  Direct Dark Matter Detectors
 
@@ -251,9 +251,9 @@ The purpose of this note is to collect references for modern machine learning as
             * [Particle Track Reconstruction using Geometric Deep Learning](https://arxiv.org/abs/2012.08515)
             * [Deep-Learning based Reconstruction of the Shower Maximum $X_{\mathrm{max}}$ using the Water-Cherenkov Detectors of the Pierre Auger Observatory](https://arxiv.org/abs/2101.02946)
             * [A comparison of optimisation algorithms for high-dimensional particle and astrophysics applications](https://arxiv.org/abs/2101.04525)
-            * [Tackling the muon identification in water Cherenkov detectors problem for the future Southern Wide-field Gamma-ray Observatory by means of Machine Learning](https://arxiv.org/abs/{2101.11924)
+            * [Tackling the muon identification in water Cherenkov detectors problem for the future Southern Wide-field Gamma-ray Observatory by means of Machine Learning](https://arxiv.org/abs/2101.11924)
             * [Muon identification in a compact single-layered water Cherenkov detector and gamma/hadron discrimination using Machine Learning techniques](https://arxiv.org/abs/2101.10109)
-            * [A convolutional-neural-network estimator of CMB constraints on dark matter energy injection](https://arxiv.org/abs/{2101.10360)
+            * [A convolutional-neural-network estimator of CMB constraints on dark matter energy injection](https://arxiv.org/abs/2101.10360)
 
         *  Tracking
 
@@ -267,7 +267,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [First application of machine learning algorithms to the position reconstruction in Resistive Silicon Detectors](https://arxiv.org/abs/2011.02410)
             * [Beyond 4D Tracking: Using Cluster Shapes for Track Seeding](https://arxiv.org/abs/2012.04533)
             * [Hashing and metric learning for charged particle tracking](https://arxiv.org/abs/2101.06428)
-            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/{2101.11906)
+            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/2101.11906)
 
         *  Heavy ions
 
@@ -328,7 +328,7 @@ The purpose of this note is to collect references for modern machine learning as
 
         *  Attention
 
-            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/{2101.11906)
+            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/2101.11906)
 
         *  Software
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [Jet Flavor Classification in High-Energy Physics with Deep Neural Networks](https://arxiv.org/abs/1607.08633) [[DOI](https://doi.org/10.1103/PhysRevD.94.112002)]
             * [Topology classification with deep learning to improve real-time event selection at the LHC](https://arxiv.org/abs/1807.00083) [[DOI](https://doi.org/10.1007/s41781-019-0028-1)]
             * [Jet Flavour Classification Using DeepJet](https://arxiv.org/abs/2008.10519)
-            * [{Development of a Vertex Finding Algorithm using Recurrent Neural Network ](https://arxiv.org/abs/{2101.11906)
+            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/{2101.11906)
 
         *  Trees
 
@@ -235,7 +235,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [Semantic Segmentation with a Sparse Convolutional Neural Network for Event Reconstruction in MicroBooNE](https://arxiv.org/abs/2012.08513)
             * [Quantum Convolutional Neural Networks for High Energy Physics Data Analysis](https://arxiv.org/abs/2012.12177)
             * [Vertex and Energy Reconstruction in JUNO with Machine Learning Methods](https://arxiv.org/abs/2101.04839)
-            * [{A Convolutional Neural Network based Cascade Reconstruction for the IceCube Neutrino Observatory ](https://arxiv.org/abs/{2101.11589)
+            * [A Convolutional Neural Network based Cascade Reconstruction for the IceCube Neutrino Observatory](https://arxiv.org/abs/{2101.11589)
 
         *  Direct Dark Matter Detectors
 
@@ -251,9 +251,9 @@ The purpose of this note is to collect references for modern machine learning as
             * [Particle Track Reconstruction using Geometric Deep Learning](https://arxiv.org/abs/2012.08515)
             * [Deep-Learning based Reconstruction of the Shower Maximum $X_{\mathrm{max}}$ using the Water-Cherenkov Detectors of the Pierre Auger Observatory](https://arxiv.org/abs/2101.02946)
             * [A comparison of optimisation algorithms for high-dimensional particle and astrophysics applications](https://arxiv.org/abs/2101.04525)
-            * [{Tackling the muon identification in water Cherenkov detectors problem for the future Southern Wide-field Gamma-ray Observatory by means of Machine Learning ](https://arxiv.org/abs/{2101.11924)
+            * [Tackling the muon identification in water Cherenkov detectors problem for the future Southern Wide-field Gamma-ray Observatory by means of Machine Learning](https://arxiv.org/abs/{2101.11924)
             * [Muon identification in a compact single-layered water Cherenkov detector and gamma/hadron discrimination using Machine Learning techniques](https://arxiv.org/abs/2101.10109)
-            * [{A convolutional-neural-network estimator of CMB constraints on dark matter energy injection ](https://arxiv.org/abs/{2101.10360)
+            * [A convolutional-neural-network estimator of CMB constraints on dark matter energy injection](https://arxiv.org/abs/{2101.10360)
 
         *  Tracking
 
@@ -267,7 +267,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [First application of machine learning algorithms to the position reconstruction in Resistive Silicon Detectors](https://arxiv.org/abs/2011.02410)
             * [Beyond 4D Tracking: Using Cluster Shapes for Track Seeding](https://arxiv.org/abs/2012.04533)
             * [Hashing and metric learning for charged particle tracking](https://arxiv.org/abs/2101.06428)
-            * [{Development of a Vertex Finding Algorithm using Recurrent Neural Network ](https://arxiv.org/abs/{2101.11906)
+            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/{2101.11906)
 
         *  Heavy ions
 
@@ -328,7 +328,7 @@ The purpose of this note is to collect references for modern machine learning as
 
         *  Attention
 
-            * [{Development of a Vertex Finding Algorithm using Recurrent Neural Network ](https://arxiv.org/abs/{2101.11906)
+            * [Development of a Vertex Finding Algorithm using Recurrent Neural Network](https://arxiv.org/abs/{2101.11906)
 
         *  Software
 


### PR DESCRIPTION
As a temporary fix for Issue #49, this PR simply applies quotes (`"`) around the BibTeX fields `title` and `eprint` in the `.bib` file. Quoting allows for the fields to be properly parsed, but a follow up PR should address Issue #49 by making the parsing more robust.

```
* Apply quotes around BibTeX 'title' and 'eprint' BibTeX fields to allow for proper parsing
   - Temporary fix 
   - c.f. https://github.com/iml-wg/HEPML-LivingReview/issues/49
```