### PR TITLE
paper: Add GNN papers for top-Higgs coupling and stop pair production

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -3647,6 +3647,20 @@ year={2020}
       SLACcitation   = "%%CITATION = ARXIV:1902.07180;%%"
 }
 
+% Januray 17, 2019
+@article{Ren:2019xhp,
+    author = "Ren, Jie and Wu, Lei and Yang, Jin Min",
+    title = "{Unveiling CP property of top-Higgs coupling with graph neural networks at the LHC}",
+    eprint = "1901.05627",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.1016/j.physletb.2020.135198",
+    journal = "Phys. Lett. B",
+    volume = "802",
+    pages = "135198",
+    year = "2020"
+}
+
 %November 30, 2018
 @article{Alonso-Monsalve:2018aqs,
     author = "Alonso-Monsalve, Saúl and Whitehead, Leigh H.",
@@ -3726,6 +3740,20 @@ year={2020}
     volume = "10",
     pages = "101",
     year = "2018"
+}
+
+% July 24, 2018
+@article{Abdughani:2018wrw,
+    author = "Abdughani, Murat and Ren, Jie and Wu, Lei and Yang, Jin Min",
+    title = "{Probing stop pair production at the LHC with graph neural networks}",
+    eprint = "1807.09088",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    doi = "10.1007/JHEP08(2019)055",
+    journal = "JHEP",
+    volume = "08",
+    pages = "055",
+    year = "2019"
 }
 
 % July 8, 2018

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -59,7 +59,7 @@ The purpose of this note is to collect references for modern machine learning as
 				\\\textit{Data that have a variable with a particular order may be represented as a sequence.  Recurrent neural networks are natural tools for processing sequence data. }
 				\item \textbf{Trees}~\cite{Louppe:2017ipp,Cheng:2017rdo}
 				\\\textit{Recursive neural networks are natural tools for processing data in a tree structure.}
-				\item \textbf{Graphs}~\cite{Henrion:DLPS2017,Ju:2020xty,Martinez:2018fwc,Moreno:2019bmu,Qasim:2019otl,Chakraborty:2019imr,Chakraborty:2020yfc,1797439,1801423,1808887,Iiyama:2020wap,1811770,Choma:2020cry,alonsomonsalve2020graph,guo2020boosted,Heintz:2020soy,Verma:2020gnq,Dreyer:2020brq,Qian:2021vnh,Pata:2021oez}
+				\item \textbf{Graphs}~\cite{Henrion:DLPS2017,Ju:2020xty,Abdughani:2018wrw,Martinez:2018fwc,Ren:2019xhp,Moreno:2019bmu,Qasim:2019otl,Chakraborty:2019imr,Chakraborty:2020yfc,1797439,1801423,1808887,Iiyama:2020wap,1811770,Choma:2020cry,alonsomonsalve2020graph,guo2020boosted,Heintz:2020soy,Verma:2020gnq,Dreyer:2020brq,Qian:2021vnh,Pata:2021oez}
 				\\\textit{A graph is a collection of nodes and edges.  Graph neural networks are natural tools for processing data in a tree structure.}
 				\item \textbf{Sets (point clouds)}~\cite{Komiske:2018cqr,Qu:2019gqs,Mikuni:2020wpr,Shlomi:2020ufi,Dolan:2020qkr,Fenton:2020woz,Lee:2020qil,collado2021learning}
 				\\\textit{A point cloud is a (potentially variable-size) set of points in space.  Sets are distinguished from sequences in that there is no particular order (i.e. permutation invariance).  Sets can also be viewed as graphs without edges and so graph methods that can parse variable-length inputs may also be appropriate for set learning, although there are other methods as well.}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ The purpose of this note is to collect references for modern machine learning as
 
             * [Neural Message Passing for Jet Physics](https://dl4physicalsciences.github.io/files/nips_dlps_2017_29.pdf})
             * [Graph Neural Networks for Particle Reconstruction in High Energy Physics detectors](https://arxiv.org/abs/2003.11603)
+            * [Probing stop pair production at the LHC with graph neural networks](https://arxiv.org/abs/1807.09088) [[DOI](https://doi.org/10.1007/JHEP08(2019)055)]
             * [Pileup mitigation at the Large Hadron Collider with graph neural networks](https://arxiv.org/abs/1810.07988) [[DOI](https://doi.org/10.1140/epjp/i2019-12710-3)]
+            * [Unveiling CP property of top-Higgs coupling with graph neural networks at the LHC](https://arxiv.org/abs/1901.05627) [[DOI](https://doi.org/10.1016/j.physletb.2020.135198)]
             * [JEDI-net: a jet identification algorithm based on interaction networks](https://arxiv.org/abs/1908.05318) [[DOI](https://doi.org/10.1140/epjc/s10052-020-7608-4)]
             * [Learning representations of irregular particle-detector geometry with distance-weighted graph networks](https://arxiv.org/abs/1902.07987) [[DOI](https://doi.org/10.1140/epjc/s10052-019-7113-9)]
             * [Interpretable deep learning for two-prong jet classification with jet spectra](https://arxiv.org/abs/1904.02092) [[DOI](https://doi.org/10.1007/JHEP07(2019)135)]


### PR DESCRIPTION
Add [Unveiling CP property of top-Higgs coupling with graph neural networks at the LHC](https://inspirehep.net/literature/1714710) and [Probing stop pair production at the LHC with graph neural networks](https://inspirehep.net/literature/1683688).

```
* Add reference for 'Unveiling CP property of top-Higgs coupling with graph neural networks at the LHC'
   - c.f. https://arxiv.org/abs/1901.05627
* Add reference for 'Probing stop pair production at the LHC with graph neural networks'
   - c.f. https://arxiv.org/abs/1807.09088
* Add links to Graphs section
```