### PR TITLE
paper: Resurrecting bbh with kinematic shapes

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -544,6 +544,18 @@
     year = "2020"
 }
 
+% November 27, 2020
+@article{Grojean:2020ech,
+    author = "Grojean, Christophe and Paul, Ayan and Qian, Zhuoni",
+    title = "{Resurrecting $b\bar{b}h$ with kinematic shapes}",
+    eprint = "2011.13945",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "DESY-20-175, HU-EP-20/28",
+    month = "11",
+    year = "2020"
+}
+
 %Nov. 26
 @article{Agarwal:2020fpt,
     author = "Agarwal, Garvita and Hay, Lauren and Iashvili, Ia and Mannix, Benjamin and McLean, Christine and Morris, Margaret and Rappoccio, Salvatore and Schubert, Ulrich",

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -72,8 +72,6 @@ The purpose of this note is to collect references for modern machine learning as
 			\\\textit{Boosted, hadronically decaying $W$ and $Z$ bosons form jets that are distinguished from generic quark and gluon jets by their mass near the boson mass and their two-prong substructure.}
 			\item \textbf{$H\rightarrow b\bar{b}$}~\cite{Datta:2019ndh,Lin:2018cin,Moreno:2019neq,Chakraborty:2019imr,Sirunyan:2020lcu,Chung:2020ysf,Tannenwald:2020mhq,guo2020boosted,Abbas:2020khd}
 			\\\textit{Due to the fidelity of $b$-tagging, boosted, hadronically decaying Higgs bosons (predominantly decaying to $b\bar{b}$) has unique challenged and opportunities compared with $W/Z$ tagging.}
-			\item \textbf{$b$-Yukawa measurememts}~\cite{Grojean:2020ech}
-			\\\textit{Measurement of the $b$-Yukawa from channels other than $H\rightarrow b\bar{b}$ can be competitive at HL-LHC and FCC-hh}
 			\item \textbf{quarks and gluons}~\cite{ATL-PHYS-PUB-2017-017,Komiske:2016rsd,Cheng:2017rdo,Stoye:DLPS2017,Chien:2018dfn,Moreno:2019bmu,Kasieczka:2018lwf,1806025,Lee:2019ssx,Lee:2019cad,Dreyer:2020brq}
 			\\\textit{Quark jets tend to be narrower and have fewer particles than gluon jets.  This classification task has been a benchmark for many new machine learning models.}
 			\item \textbf{top quark} tagging~\cite{Almeida:2015jua,Stoye:DLPS2017,Kasieczka:2019dbj,Chakraborty:2020yfc,Diefenbacher:2019ezd,Butter:2017cot,Kasieczka:2017nvn,Macaluso:2018tck,Bhattacharya:2020vzu,Lim:2020igi,Dreyer:2020brq,Aguilar-Saavedra:2021rjk}

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -63,7 +63,7 @@ The purpose of this note is to collect references for modern machine learning as
 				\\\textit{A graph is a collection of nodes and edges.  Graph neural networks are natural tools for processing data in a tree structure.}
 				\item \textbf{Sets (point clouds)}~\cite{Komiske:2018cqr,Qu:2019gqs,Mikuni:2020wpr,Shlomi:2020ufi,Dolan:2020qkr,Fenton:2020woz,Lee:2020qil,collado2021learning,Mikuni:2021pou}
 				\\\textit{A point cloud is a (potentially variable-size) set of points in space.  Sets are distinguished from sequences in that there is no particular order (i.e. permutation invariance).  Sets can also be viewed as graphs without edges and so graph methods that can parse variable-length inputs may also be appropriate for set learning, although there are other methods as well.}
-				\item \textbf{Physics-inspired basis}~\cite{Datta:2019,Datta:2017rhs,Datta:2017lxt,Komiske:2017aww,Butter:2017cot}
+				\item \textbf{Physics-inspired basis}~\cite{Datta:2019,Datta:2017rhs,Datta:2017lxt,Komiske:2017aww,Butter:2017cot,Grojean:2020ech}
 				\\\textit{This is a catch-all category for learning using other representations that use some sort of manual or automated physics-preprocessing.}
 			\end{itemize}
 		\item Targets
@@ -72,6 +72,8 @@ The purpose of this note is to collect references for modern machine learning as
 			\\\textit{Boosted, hadronically decaying $W$ and $Z$ bosons form jets that are distinguished from generic quark and gluon jets by their mass near the boson mass and their two-prong substructure.}
 			\item \textbf{$H\rightarrow b\bar{b}$}~\cite{Datta:2019ndh,Lin:2018cin,Moreno:2019neq,Chakraborty:2019imr,Sirunyan:2020lcu,Chung:2020ysf,Tannenwald:2020mhq,guo2020boosted,Abbas:2020khd}
 			\\\textit{Due to the fidelity of $b$-tagging, boosted, hadronically decaying Higgs bosons (predominantly decaying to $b\bar{b}$) has unique challenged and opportunities compared with $W/Z$ tagging.}
+			\item \textbf{$b$-Yukawa measurememts}~\cite{Grojean:2020ech}
+			\\\textit{Measurement of the $b$-Yukawa from channels other than $H\rightarrow b\bar{b}$ can be competitive at HL-LHC and FCC-hh}
 			\item \textbf{quarks and gluons}~\cite{ATL-PHYS-PUB-2017-017,Komiske:2016rsd,Cheng:2017rdo,Stoye:DLPS2017,Chien:2018dfn,Moreno:2019bmu,Kasieczka:2018lwf,1806025,Lee:2019ssx,Lee:2019cad,Dreyer:2020brq}
 			\\\textit{Quark jets tend to be narrower and have fewer particles than gluon jets.  This classification task has been a benchmark for many new machine learning models.}
 			\item \textbf{top quark} tagging~\cite{Almeida:2015jua,Stoye:DLPS2017,Kasieczka:2019dbj,Chakraborty:2020yfc,Diefenbacher:2019ezd,Butter:2017cot,Kasieczka:2017nvn,Macaluso:2018tck,Bhattacharya:2020vzu,Lim:2020igi,Dreyer:2020brq,Aguilar-Saavedra:2021rjk}
@@ -110,7 +112,7 @@ The purpose of this note is to collect references for modern machine learning as
 				\\\textit{Instead of learning to distinguish different types of examples, the goal of reinforcement learning is to learn a strategy (policy).  The prototypical example of reinforcement learning in learning a strategy to play video games using some kind of score as a feedback during the learning.}
 				\item \textbf{Quantum Machine Learning}~\cite{Mott:2017xdb,Zlokapa:2019lvv,Blance:2020nhl,Terashi:2020wfi,Chen:2020zkj,Wu:2020cye,Guan:2020bdl,Chen:2021ouz}
 				\\\textit{Quantum computers are based on unitary operations applied to quantum states.  These states live in a vast Hilbert space which may have a usefully large information capacity for machine learning.}
-				\item \textbf{Feature ranking}~\cite{Faucett:2020vbu}
+				\item \textbf{Feature ranking}~\cite{Faucett:2020vbu,Grojean:2020ech}
 				\\\textit{It is often useful to take a set of input features and rank them based on their usefulness.}
 				\item \textbf{Attention}~\cite{goto2021development}
 				\\\textit{This is an ML tool for helping the network to focus on particularly useful features.}
@@ -183,7 +185,7 @@ The purpose of this note is to collect references for modern machine learning as
 \item \textbf{Uncertainty Quantification}
 \\\textit{Estimating and mitigating uncertainty is essential for the successful deployment of machine learning methods in high energy physics. }
 	\begin{itemize}
-		\item \textbf{Interpretability}~\cite{deOliveira:2015xxd,Chang:2017kvc,Diefenbacher:2019ezd,Agarwal:2020fpt}
+		\item \textbf{Interpretability}~\cite{deOliveira:2015xxd,Chang:2017kvc,Diefenbacher:2019ezd,Agarwal:2020fpt,Grojean:2020ech}
 		\\\textit{Machine learning methods that are interpretable maybe more robust and thus less susceptible to various sources of uncertainty.}
 		\item \textbf{Estimation}~\cite{Nachman:2019dol,Nachman:2019yfl,Barnard:2016qma}
 		\\\textit{A first step in reducing uncertainties is estimating their size.}

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [Novel Jet Observables from Machine Learning](https://arxiv.org/abs/1710.01305) [[DOI](https://doi.org/10.1007/JHEP03(2018)086)]
             * [Energy flow polynomials: A complete linear basis for jet substructure](https://arxiv.org/abs/1712.07124) [[DOI](https://doi.org/10.1007/JHEP04(2018)013)]
             * [Deep-learned Top Tagging with a Lorentz Layer](https://arxiv.org/abs/1707.08966) [[DOI](https://doi.org/10.21468/SciPostPhys.5.3.028)]
+            * [Resurrecting $b\bar{b}h$ with kinematic shapes](https://arxiv.org/abs/2011.13945)
 
         *  $W/Z$ tagging
 
@@ -152,6 +153,10 @@ The purpose of this note is to collect references for modern machine learning as
             * [Benchmarking Machine Learning Techniques with Di-Higgs Production at the LHC](https://arxiv.org/abs/2009.06754)
             * [The Boosted Higgs Jet Reconstruction via Graph Neural Network](https://arxiv.org/abs/2010.05464)
             * [Extracting Signals of Higgs Boson From Background Noise Using Deep Neural Networks](https://arxiv.org/abs/2010.08201)
+
+        *  $b$-Yukawa measurememts
+
+            * [Resurrecting $b\bar{b}h$ with kinematic shapes](https://arxiv.org/abs/2011.13945)
 
         *  quarks and gluons
 
@@ -337,6 +342,7 @@ The purpose of this note is to collect references for modern machine learning as
         *  Feature ranking
 
             * [Mapping Machine-Learned Physics into a Human-Readable Space](https://arxiv.org/abs/2010.11998)
+            * [Resurrecting $b\bar{b}h$ with kinematic shapes](https://arxiv.org/abs/2011.13945)
 
         *  Attention
 
@@ -631,6 +637,7 @@ The purpose of this note is to collect references for modern machine learning as
         * [What is the Machine Learning?](https://arxiv.org/abs/1709.10106) [[DOI](https://doi.org/10.1103/PhysRevD.97.056009)]
         * [CapsNets Continuing the Convolutional Quest](https://arxiv.org/abs/1906.11265) [[DOI](https://doi.org/10.21468/SciPostPhys.8.2.023)]
         * [Explainable AI for ML jet taggers using expert variables and layerwise relevance propagation](https://arxiv.org/abs/2011.13466)
+        * [Resurrecting $b\bar{b}h$ with kinematic shapes](https://arxiv.org/abs/2011.13945)
 
     *  Estimation
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,6 @@ The purpose of this note is to collect references for modern machine learning as
             * [The Boosted Higgs Jet Reconstruction via Graph Neural Network](https://arxiv.org/abs/2010.05464)
             * [Extracting Signals of Higgs Boson From Background Noise Using Deep Neural Networks](https://arxiv.org/abs/2010.08201)
 
-        *  $b$-Yukawa measurememts
-
-            * [Resurrecting $b\bar{b}h$ with kinematic shapes](https://arxiv.org/abs/2011.13945)
-
         *  quarks and gluons
 
             * [Quark versus Gluon Jet Tagging Using Jet Images with the ATLAS Detector](http://cds.cern.ch/record/2275641)


### PR DESCRIPTION
Add [Resurrecting bb¯h with kinematic shapes](https://inspirehep.net/literature/1833995).

```
* Add reference to 'Resurrecting bb¯h with kinematic shapes'
   - c.f. https://arxiv.org/abs/2011.13945
* Add link to sections: physics-inspired basis, feature ranking, interpretability
```

Resurrecting $b\bar{b}h$ with kinematic shapes (https://arxiv.org/abs/2011.13945) addresses the question of measuring b-Yukawa from the bbh process at HL-LHC and FCC. We use an interpretable machine learning framework with a physics-inspired basis and use Shapley values for understanding variable importance and correlations.

Authors: Christophe Grojean, @talismanbrandi, and Zhuoni Qian