### PR TITLE
paper: Add NNs for efficient evaluation of high multiplicity scattering amplitudes

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -1719,6 +1719,21 @@
     year = "2020"
 }
 
+%Feb 25, 2020
+@article{Badger:2020uow,
+    author = "Badger, Simon and Bullock, Joseph",
+    title = "{Using neural networks for efficient evaluation of high multiplicity scattering amplitudes}",
+    eprint = "2002.07516",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "IPPP/20/5",
+    doi = "10.1007/JHEP06(2020)114",
+    journal = "JHEP",
+    volume = "06",
+    pages = "114",
+    year = "2020"
+}
+
 %Feb 23, 2020
 @article{Du:2019civ,
     author = {Du, Yi-Lun and Zhou, Kai and Steinheimer, Jan and Pang, Long-Gang and Motornenko, Anton and Zong, Hong-Shi and Wang, Xin-Nian and St\"ocker, Horst},

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -137,7 +137,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\\\textit{The goal of calibration is to remove the bias (and reduce variance if possible) from detector (or related) effects.}
 		\item \textbf{Recasting}~\cite{Caron:2017hku,Bertone:2016mdy,1806026}
 		\\\textit{Even though an experimental analysis may provide a single model-dependent interpretation of the result, the results are likely to have important implications for a variety of other models.  Recasting is the task of taking a result and interpreting it in the context of a model that was not used for the original analysis.}
-		\item \textbf{Matrix elements}~\cite{Bishara:2019iwh,1804325,Bury:2020ewi}
+		\item \textbf{Matrix elements}~\cite{Badger:2020uow,Bishara:2019iwh,1804325,Bury:2020ewi}
 		\\\textit{Regression methods can be used as surrogate models for functions that are too slow to evaluate.  One important class of functions are matrix elements, which form the core component of cross section calculations in quantum field theory.}
 		\item \textbf{Parameter estimation}~\cite{Lei:2020ucb,1808105,Lazzarin:2020uvv}
 		\\\textit{The target features could be parameters of a model, which can be learned directly through a regression setup.  Other forms of inference are described in later sections (which could also be viewed as regression).}

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ The purpose of this note is to collect references for modern machine learning as
 
     *  Matrix elements
 
+        * [Using neural networks for efficient evaluation of high multiplicity scattering amplitudes](https://arxiv.org/abs/2002.07516) [[DOI](https://doi.org/10.1007/JHEP06(2020)114)]
         * [(Machine) Learning Amplitudes for Faster Event Generation](https://arxiv.org/abs/1912.11055)
         * [$\textsf{Xsec}$: the cross-section evaluation code](https://arxiv.org/abs/2006.16273)
         * [Matrix Element Regression with Deep Neural Networks -- breaking the CPU barrier](https://arxiv.org/abs/2008.10949)


### PR DESCRIPTION
Add [Using neural networks for efficient evaluation of high multiplicity scattering amplitudes](https://inspirehep.net/literature/1781330).

```
* Add reference to 'Using neural networks for efficient evaluation of high multiplicity scattering amplitudes'
   - c.f. https://arxiv.org/abs/2002.07516
* Add link to sections: Matrix elements
```