### PR TITLE
fix: Install Python requirements in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --quiet --no-cache-dir --requirement requirements.txt
+        python -m pip list
     - name: Test README generation
       run: |
         cp README.md README.bak

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,11 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --quiet --no-cache-dir --requirement requirements.txt
+        python -m pip list
     - name: Generate README
       run: |
         cp README.md README.bak

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,28 @@
 repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-merge-conflict
+    - id: check-symlinks
+    - id: check-json
+    - id: check-yaml
+    - id: check-toml
+    - id: check-xml
+    - id: debug-statements
+    - id: end-of-file-fixer
+    - id: mixed-line-ending
+    - id: requirements-txt-fixer
+    - id: trailing-whitespace
+
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.11.0
     hooks:
     - id: pyupgrade
       args: ["--py37-plus"]
+
+-   repo: https://github.com/pycqa/isort
+    rev: 5.7.0
+    hooks:
+    - id: isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     - id: check-toml
     - id: check-xml
     - id: debug-statements
-    - id: end-of-file-fixer
+    # - id: end-of-file-fixer # TODO: Fix make_md.py
     - id: mixed-line-ending
     - id: requirements-txt-fixer
     - id: trailing-whitespace

--- a/HEPML.bib
+++ b/HEPML.bib
@@ -1879,7 +1879,7 @@
 
 %June 11
 @misc{deja2020endtoend,
-      title={End-to-end Sinkhorn Autoencoder with Noise Generator}, 
+      title={End-to-end Sinkhorn Autoencoder with Noise Generator},
       author={Kamil Deja and Jan Dubiński and Piotr Nowak and Sandro Wenzel and Tomasz Trzciński},
       year={2020},
       eprint={2006.06704},

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ The purpose of this note is to collect references for modern machine learning as
         * [Foundations of a Fast, Data-Driven, Machine-Learned Simulator](https://arxiv.org/abs/2101.08944)
         * [Decoding Photons: Physics in the Latent Space of a BIB-AE Generative Network](https://arxiv.org/abs/2102.12491)
         * [Bump Hunting in Latent Space](https://arxiv.org/abs/2103.06595)
-        * [{End-to-end Sinkhorn Autoencoder with Noise Generator ](https://arxiv.org/abs/{2006.06704)
+        * [{End-to-end Sinkhorn Autoencoder with Noise Generator](https://arxiv.org/abs/{2006.06704)
 
     *  Normalizing flows
 

--- a/README.md
+++ b/README.md
@@ -697,3 +697,4 @@ The purpose of this note is to collect references for modern machine learning as
         * [Search for Higgs boson decays into a $Z$ boson and a light hadronically decaying resonance using 13 TeV $pp$ collision data from the ATLAS detector](https://arxiv.org/abs/2004.01678) [[DOI](https://doi.org/10.1103/PhysRevLett.125.221802)]
         * [Dijet resonance search with weak supervision using 13 TeV pp collisions in the ATLAS detector](https://arxiv.org/abs/2005.02983) [[DOI](https://doi.org/10.1103/PhysRevLett.125.131801)]
         * [Inclusive search for highly boosted Higgs bosons decaying to bottom quark-antiquark pairs in proton-proton collisions at $\sqrt{s}](https://arxiv.org/abs/2006.13251) [[DOI](https://doi.org/10.1007/JHEP12(2020)085)]
+

--- a/README.md
+++ b/README.md
@@ -697,4 +697,3 @@ The purpose of this note is to collect references for modern machine learning as
         * [Search for Higgs boson decays into a $Z$ boson and a light hadronically decaying resonance using 13 TeV $pp$ collision data from the ATLAS detector](https://arxiv.org/abs/2004.01678) [[DOI](https://doi.org/10.1103/PhysRevLett.125.221802)]
         * [Dijet resonance search with weak supervision using 13 TeV pp collisions in the ATLAS detector](https://arxiv.org/abs/2005.02983) [[DOI](https://doi.org/10.1103/PhysRevLett.125.131801)]
         * [Inclusive search for highly boosted Higgs bosons decaying to bottom quark-antiquark pairs in proton-proton collisions at $\sqrt{s}](https://arxiv.org/abs/2006.13251) [[DOI](https://doi.org/10.1007/JHEP12(2020)085)]
-

--- a/footnote_build_info.py
+++ b/footnote_build_info.py
@@ -1,5 +1,5 @@
-import subprocess
 import os
+import subprocess
 from shutil import copyfile
 
 

--- a/make_md.py
+++ b/make_md.py
@@ -1,6 +1,7 @@
-import os
-import requests
 import json
+import os
+
+import requests
 import yaml
 
 update_journal = False
@@ -46,7 +47,7 @@ def summarize_record(recid):
             mini_dict.update({'page_start':data['publication_info'][0]['page_start']})
         if 'journal_year' in data:
             mini_dict.update({'journal_year':data['publication_info'][0]['year']})
-        
+
         if 'dois' in data:
             mini_dict.update({'doi': data['dois'][0]['value']})
     return mini_dict

--- a/make_md.py
+++ b/make_md.py
@@ -93,7 +93,6 @@ def convert_from_bib(myline):
             pass
         pass
 
-    print(myline)
     if "eprint" in myentry_dict and 'doi' not in myentry_dict and update_journal:
         #check inspire
         inspire_dict = summarize_record(myentry_dict['eprint'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML
-requests
+PyYAML~=5.3
+requests~=2.25


### PR DESCRIPTION
Fix regression in 2c3d565633304a6b72a13c404af066a86f6a3300 by adding the required dependencies and installing them in the CI workflow.

```
* Add required dependencies in requirements.txt
* Update and apply pre-commit hooks
   - Add pre-commit and isort
* Install required dependencies in the CI/CD workflows
```