### PR TITLE
Fixed the link for arXiv:1804.09720

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -3051,7 +3051,7 @@
 @article{Andreassen:2018apy,
 	Archiveprefix = {arXiv},
 	Author = {Andreassen, Anders and Feige, Ilya and Frye, Christopher and Schwartz, Matthew D.},
-	eprint = {1804.09720},
+	eprint = 1804.09720,
 	Primaryclass = {hep-ph},
 	Slaccitation = {%%CITATION = ARXIV:1804.09720;%%},
 	title = "{JUNIPR: a Framework for Unsupervised Machine Learning in Particle Physics}",

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ The purpose of this note is to collect references for modern machine learning as
 
     *  Physics-inspired
 
-        * [JUNIPR: a Framework for Unsupervised Machine Learning in Particle Physics](https://arxiv.org/abs/{1804.09720)
+        * [JUNIPR: a Framework for Unsupervised Machine Learning in Particle Physics](https://arxiv.org/abs/1804.09720)
         * [Binary JUNIPR: an interpretable probabilistic model for discrimination](https://arxiv.org/abs/1906.10137) [[DOI](https://doi.org/10.1103/PhysRevLett.123.182001)]
         * [Exploring the Possibility of a Recovery of Physics Process Properties from a Neural Network Model](https://arxiv.org/abs/2007.13110) [[DOI](https://doi.org/10.3390/e22090994)]
         * [Explainable machine learning of the underlying physics of high-energy particle collisions](https://arxiv.org/abs/2012.06582)


### PR DESCRIPTION
One of the links for JUNIPR paper had an issue with the link due t parenthesis, which I removed and the link now works as expected.