### PR TITLE
Add references to the NNPDF code and results

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -1,5 +1,26 @@
 # HEPML Papers
 
+%September 6, 2021
+@article{Ball:2021leu,
+    author = "Ball, Richard D. and others",
+    title = "{The Path to Proton Structure at One-Percent Accuracy}",
+    eprint = "2109.02653",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    month = "9",
+    year = "2021"
+}
+@article{Ball:2021xlu,
+    author = "Ball, Richard D. and others",
+    title = "{An open-source machine learning framework for global analyses of parton distributions}",
+    eprint = "2109.02671",
+    archivePrefix = "arXiv",
+    primaryClass = "hep-ph",
+    reportNumber = "Edinburgh 2021/13, Nikhef-2021-020, TIF-UNIMI-2021-12",
+    month = "9",
+    year = "2021"
+}
+
 %September 1, 2021
 @article{Hallin:2021wme,
     author = "Hallin, Anna and Isaacson, Joshua and Kasieczka, Gregor and Krause, Claudius and Nachman, Benjamin and Quadfasel, Tobias and Schlaffer, Matthias and Shih, David and Sommerhalder, Manuel",

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -142,7 +142,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\\\textit{Regression methods can be used as surrogate models for functions that are too slow to evaluate.  One important class of functions are matrix elements, which form the core component of cross section calculations in quantum field theory.}
 		\item \textbf{Parameter estimation}~\cite{Lei:2020ucb,1808105,Lazzarin:2020uvv,Kim:2021pcz}
 		\\\textit{The target features could be parameters of a model, which can be learned directly through a regression setup.  Other forms of inference are described in later sections (which could also be viewed as regression).}
-		\item \textbf{Parton Distribution Functions (and related)}~\cite{DelDebbio:2020rgv,Grigsby:2020auv,Rossi:2020sbh,Carrazza:2021hny}
+		\item \textbf{Parton Distribution Functions (and related)}~\cite{DelDebbio:2020rgv,Grigsby:2020auv,Rossi:2020sbh,Carrazza:2021hny,Ball:2021leu,Ball:2021xlu}
 		\\\textit{Various machine learning models can provide flexible function approximators, which can be useful for modeling functions that cannot be determined easily from first principles such as parton distribution functions.}
 		\item \textbf{Lattice Gauge Theory}~\cite{Kanwar:2003.06413,Favoni:2020reg,Bulusu:2021rqz,Shi:2021qr,Hackett:2021idh}
 		\\\textit{Lattice methods offer a complementary approach to perturbation theory.  A key challenge is to create approaches that respect the local gauge symmetry (equivariant networks).}

--- a/README.md
+++ b/README.md
@@ -533,6 +533,8 @@ The purpose of this note is to collect references for modern machine learning as
         * [Deep Learning Analysis of Deeply Virtual Exclusive Photoproduction](https://arxiv.org/abs/2012.04801)
         * [PDFFlow: hardware accelerating parton density access](https://arxiv.org/abs/2012.08221) [[DOI](https://doi.org/10.5821/zenodo.4286175)]
         * [Compressing PDF sets using generative adversarial networks](https://arxiv.org/abs/2104.04535)
+        * [The Path to Proton Structure at One-Percent Accuracy](https://arxiv.org/abs/2109.02653)
+        * [An open-source machine learning framework for global analyses of parton distributions](https://arxiv.org/abs/2109.02671)
 
     *  Lattice Gauge Theory
 


### PR DESCRIPTION
Add the reference of 4.0 paper containing a description of the
hyperoprimization and fitting methodology as well as other potentially
relevant issues such as validation tests or decorrelation.

Add a reference to the NNPDF code, which has been newly made open source
and contains all the data and code required to reproduce the PDF sets,
as well as ancillary analysis.

Closes #80.