### PR TITLE
Add 'Accelerating Monte Carlo event generation' to Matrix Elements section

### DIFF
--- a/HEPML.tex
+++ b/HEPML.tex
@@ -138,7 +138,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\\\textit{The goal of calibration is to remove the bias (and reduce variance if possible) from detector (or related) effects.}
 		\item \textbf{Recasting}~\cite{Caron:2017hku,Bertone:2016mdy,1806026}
 		\\\textit{Even though an experimental analysis may provide a single model-dependent interpretation of the result, the results are likely to have important implications for a variety of other models.  Recasting is the task of taking a result and interpreting it in the context of a model that was not used for the original analysis.}
-		\item \textbf{Matrix elements}~\cite{Badger:2020uow,Bishara:2019iwh,1804325,Bury:2020ewi,Sombillo:2021yxe,Sombillo:2021rxv,Aylett-Bullock:2021hmo,Maitre:2021uaa}
+		\item \textbf{Matrix elements}~\cite{Badger:2020uow,Bishara:2019iwh,1804325,Bury:2020ewi,Sombillo:2021yxe,Sombillo:2021rxv,Aylett-Bullock:2021hmo,Maitre:2021uaa,Danziger:2021eeg}
 		\\\textit{Regression methods can be used as surrogate models for functions that are too slow to evaluate.  One important class of functions are matrix elements, which form the core component of cross section calculations in quantum field theory.}
 		\item \textbf{Parameter estimation}~\cite{Lei:2020ucb,1808105,Lazzarin:2020uvv,Kim:2021pcz,Alda:2021rgt}
 		\\\textit{The target features could be parameters of a model, which can be learned directly through a regression setup.  Other forms of inference are described in later sections (which could also be viewed as regression).}

--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ The purpose of this note is to collect references for modern machine learning as
         * [Model independent analysis of coupled-channel scattering: a deep learning approach](https://arxiv.org/abs/2105.04898)
         * [Optimising simulations for diphoton production at hadron colliders using amplitude neural networks](https://arxiv.org/abs/2106.09474)
         * [A factorisation-aware Matrix element emulator](https://arxiv.org/abs/2107.06625)
+        * [Accelerating Monte Carlo event generation -- rejection sampling using neural network event-weight estimates](https://arxiv.org/abs/2109.11964)
 
     *  Parameter estimation
 


### PR DESCRIPTION
This was already included in the phase space generation section, but is also (and dominantly) about ME surrogates and their application for unweighting.

```
* Add 'Accelerating Monte Carlo event generation -- rejection sampling
using neural network event-weight estimates' to the Matrix Elements section
of the review
   - c.f. https://inspirehep.net/literature/1927689
```