### PR TITLE
fix: Correct citation key for 'Heavy Quark Potential in QGP' paper

### DIFF
--- a/HEPML.tex
+++ b/HEPML.tex
@@ -144,7 +144,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\\\textit{The target features could be parameters of a model, which can be learned directly through a regression setup.  Other forms of inference are described in later sections (which could also be viewed as regression).}
 		\item \textbf{Parton Distribution Functions (and related)}~\cite{DelDebbio:2020rgv,Grigsby:2020auv,Rossi:2020sbh,Carrazza:2021hny,Ball:2021leu,Ball:2021xlu,Khalek:2021gon}
 		\\\textit{Various machine learning models can provide flexible function approximators, which can be useful for modeling functions that cannot be determined easily from first principles such as parton distribution functions.}
-		\item \textbf{Lattice Gauge Theory}~\cite{Kanwar:2003.06413,Favoni:2020reg,Bulusu:2021rqz,Shi:2021qr,Hackett:2021idh,Yoon:2018krb,Zhang:2019qiq,Nguyen:2019gpo}
+		\item \textbf{Lattice Gauge Theory}~\cite{Kanwar:2003.06413,Favoni:2020reg,Bulusu:2021rqz,Shi:2021qri,Hackett:2021idh,Yoon:2018krb,Zhang:2019qiq,Nguyen:2019gpo}
 		\\\textit{Lattice methods offer a complementary approach to perturbation theory.  A key challenge is to create approaches that respect the local gauge symmetry (equivariant networks).}
 		\item \textbf{Function Approximation}~\cite{1853982,Haddadin:2021mmo}
 		\\\textit{Approximating functions that obey certain (physical) constraints.}


### PR DESCRIPTION
Migrated from PR #86 for atomicity.

Typo: 'Shi:2021qr' -> 'Shi:2021qri'