### PR TITLE
Adding reference to SVM papers in HEP

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -6827,6 +6827,22 @@ SLACcitation   = "%%CITATION = ARXIV:1805.00020;%%"
  url            = "{https://dl4physicalsciences.github.io/files/nips_dlps_2017_29.pdf}"
 }
 
+% Novembre 23, 2017
+@article{Bevan:2017stx,
+ author = "Bevan, Adrian and Go~ni, Rodrigo Gamboa and Stevenson, Tom and Stevenson, Tom",
+ editor = "Mount, Richard and Tull, Craig",
+ title = "{Support vector machines and generalisation in HEP}",
+ eprint = "1702.04686",
+ archivePrefix = "arXiv",
+ primaryClass = "physics.data-an",
+ doi = "10.1088/1742-6596/898/7/072021",
+ journal = "J. Phys. Conf. Ser.",
+ volume = "898",
+ number = "7",
+ pages = "072021",
+ year = "2017"
+}
+
 % November 7, 2017
 @article{Cheng:2017rdo,
  author         = "Cheng, Taoli",
@@ -7221,6 +7237,20 @@ SLACcitation   = "%%CITATION = ARXIV:1805.00020;%%"
  eprint         = "1402.4735",
  archivePrefix  = "arXiv",
  primaryClass   = "hep-ph",
+}
+
+% September 11, 2013
+@article{Sforza:2013hua,
+ author = "Sforza, Federico and Lippi, Vittorio",
+ title = "{Support vector machine classification on a biased training set: Multi-jet background rejection at hadron colliders}",
+ eprint = "1407.0317",
+ archivePrefix = "arXiv",
+ primaryClass = "hep-ex",
+ doi = "10.1016/j.nima.2013.04.046",
+ journal = "Nucl. Instrum. Meth. A",
+ volume = "722",
+ pages = "11--19",
+ year = "2013"
 }
 
 % May 30, 2013

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -101,7 +101,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\item \textbf{Learning strategies}
 		\\\textit{There is no unique way to train a classifier and designing an effective learning strategy is often one of the biggest challenges for achieving optimality.}
 			\begin{itemize}
-				\item \textbf{Hyperparameters}~\cite{Tani:2020dyi,Dudko:2021cie}
+				\item \textbf{Hyperparameters}~\cite{Tani:2020dyi,Dudko:2021cie,Bevan:2017stx}
 				\\\textit{In addition to learnable weights $w$, classifiers have a number of non-differentiable parameters like the number of layers in a neural network.  These parameters are called hyperparameters.}
 				\item \textbf{Weak/Semi supervision}~\cite{Dery:2017fap,Metodiev:2017vrx,Komiske:2018oaa,Collins:2018epr,Collins:2019jip,Borisyak:2019vbz,Cohen:2017exh,Komiske:2018vkc,Metodiev:2018ftz,collaboration2020dijet,Amram:2020ykb,Brewer:2020och,Dahbi:2020zjw,Lee:2019ssx,Lieberman:2021krq}
 				\\\textit{For supervised learning, the labels $y_i$ are known.  In the case that the labels are noisy or only known with some uncertainty, then the learning is called weak supervision.  Semi-supervised learning is the related case where labels are known for only a fraction of the training examples.}
@@ -115,7 +115,7 @@ The purpose of this note is to collect references for modern machine learning as
 				\\\textit{It is often useful to take a set of input features and rank them based on their usefulness.}
 				\item \textbf{Attention}~\cite{goto2021development}
 				\\\textit{This is an ML tool for helping the network to focus on particularly useful features.}
-				\item \textbf{Regularization}~\cite{Araz:2021wqm}
+				\item \textbf{Regularization}~\cite{Araz:2021wqm,Sforza:2013hua}
 				\\\textit{This is a term referring to any learning strategy that improves the robustness of a classifier to statistical fluctuations in the data and in the model initialization.}
 				\item \textbf{Optimal Transport}~\cite{Komiske:2019fks,Cai:2020vzx,Romao:2020ojy,Pollard:2021fqv,Cai:2021hnn}
 				\\\textit{Optimal transport is a set of tools for transporting one probability density into another and can be combined with other strategies for classification, regression, etc.  The above citation list does not yet include papers using optimal transport distances as part of generative model training.}


### PR DESCRIPTION
adding reference to SVM papers in HEP: one [sforza,lippi 2013] focusing on robustness of classification, the other [bevan, et al. 2017] focusing on hyperparameter optimization for SVM