### PR TITLE
chore: Remove unused PyYAML and json dependencies

### DIFF
--- a/make_md.py
+++ b/make_md.py
@@ -1,8 +1,6 @@
-import json
 import os
 
 import requests
-import yaml
 
 update_journal = False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML~=5.3
+PyYAML~=6.0
 requests~=2.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML~=6.0
-requests~=2.25
+requests~=2.27

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-PyYAML~=6.0
 requests~=2.27


### PR DESCRIPTION
Neither `PyYAML` or the `json` module are used at all, so remove their imports and remove `PyYAML` from `requirements.txt`

```
* Remove unused imports of PyYAML and json
* Remove unused PyYAML dependencies from requirements.txt
* Update requests compatible release versions to v2.x
```