### PR TITLE
fix: Properly select } in \textbf argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [Jet tagging in the Lund plane with graph networks](https://arxiv.org/abs/2012.08526) [[DOI](https://doi.org/10.1007/JHEP03(2021)052)]
             * [A $W^\pm$ polarization analyzer from Deep Neural Networks](https://arxiv.org/abs/2102.05124)
 
-        *  $H\rightarrow b\bar{b$}
+        *  $H\rightarrow b\bar{b}$
 
             * [Automating the Construction of Jet Observables with Machine Learning](https://arxiv.org/abs/1902.07180) [[DOI](https://doi.org/10.1103/PhysRevD.100.095016)]
             * [Boosting $H\to b\bar b$ with Machine Learning](https://arxiv.org/abs/1807.10768) [[DOI](https://doi.org/10.1007/JHEP10(2018)101)]

--- a/make_md.py
+++ b/make_md.py
@@ -1,5 +1,4 @@
 import os
-import re
 
 import requests
 

--- a/make_md.py
+++ b/make_md.py
@@ -2,6 +2,8 @@ import os
 
 import requests
 
+import re
+
 update_journal = False
 
 myfile = open("HEPML.tex")
@@ -148,12 +150,16 @@ for line in myfile:
         continue
 
     if "\\item \\textbf{" in line:
-        line = line[0:line.find("}")]+line[line.find("}")+1:-1]
-    line = line.replace("\\textbf{","")
+        line = line.replace("\\textbf{","")
+        i = line.find("}")
+        j = line.find("{")
+        while j != -1 and j < i:
+            i = line.find("}", i+1)
+            j = line.find("{", i+1)
+        line = line[0:i]+line[i+1:-1]
 
     if "textit{" in line:
         continue
-
     if "item" in line:
         if "begin{itemize}" in line:
             itemize_counter+=1

--- a/make_md.py
+++ b/make_md.py
@@ -155,7 +155,7 @@ for line in myfile:
         while j != -1 and j < i:
             i = line.find("}", i+1)
             j = line.find("{", i+1)
-        line = line[0:i]+line[i+1:-1]
+        line = line[:i] + line[i+1:-1]
 
     if "textit{" in line:
         continue

--- a/make_md.py
+++ b/make_md.py
@@ -1,8 +1,7 @@
 import os
+import re
 
 import requests
-
-import re
 
 update_journal = False
 


### PR DESCRIPTION
This was causing the category $H\rightarrow b\bar{b}$ to break.

```
* Allow for } to exist inside of `\textbf{}` and to be properly extracted.
```