### PR TITLE
paper: Add Event Classification with Multi-step Machine Learning proceedings

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -3292,7 +3292,7 @@
     volume = "251",
     pages = "03036",
     year = "2021"
-}    
+}
 
 %June 1, 2021
 @article{Alanazi:2021grv,

--- a/HEPML.bib
+++ b/HEPML.bib
@@ -3280,6 +3280,20 @@
     year = "2021"
 }
 
+%June 4, 2021
+@article{Saito:2021vpp,
+    author = "Saito, Masahiko and Kishimoto, Tomoe and Kaneta, Yuya and Itoh, Taichi and Umeda, Yoshiaki and Tanaka, Junichi and Iiyama, Yutaro and Sawada, Ryu and Terashi, Koji",
+    title = "{Event Classification with Multi-step Machine Learning}",
+    eprint = "2106.02301",
+    archivePrefix = "arXiv",
+    primaryClass = "cs.LG",
+    doi = "10.1051/epjconf/202125103036",
+    journal = "EPJ Web Conf.",
+    volume = "251",
+    pages = "03036",
+    year = "2021"
+}    
+
 %June 1, 2021
 @article{Alanazi:2021grv,
     author = "Alanazi, Yasir and Sato, N. and Ambrozewicz, Pawel and Blin, Astrid N. Hiller and Melnitchouk, W. and Battaglieri, Marco and Liu, Tianbo and Li, Yaohang",

--- a/HEPML.tex
+++ b/HEPML.tex
@@ -123,7 +123,7 @@ The purpose of this note is to collect references for modern machine learning as
 		\item \textbf{Fast inference / deployment}
 		\\\textit{There are many practical issues that can be critical for the actual application of machine learning models.}
 			\begin{itemize}
-				\item \textbf{Software}~\cite{Strong:2020mge,Gligorov:2012qt,Weitekamp:DLPS2017,Nguyen:2018ugw,Bourgeois:2018nvk,1792136,Balazs:2021uhg,Rehm:2021zow,Mahesh:2021iph,Amrouche:2021tio,Pol:2021iqw,Goncharov:2021wvd}
+				\item \textbf{Software}~\cite{Strong:2020mge,Gligorov:2012qt,Weitekamp:DLPS2017,Nguyen:2018ugw,Bourgeois:2018nvk,1792136,Balazs:2021uhg,Rehm:2021zow,Mahesh:2021iph,Amrouche:2021tio,Pol:2021iqw,Goncharov:2021wvd,Saito:2021vpp}
 				\\\textit{Strategies for efficient inference for a given hardware architecture.}
 				\item \textbf{Hardware/firmware}~\cite{Duarte:2018ite,DiGuglielmo:2020eqx,Summers:2020xiy,1808088,Iiyama:2020wap,Mohan:2020vvi,Carrazza:2020qwu,Rankin:2020usv,Heintz:2020soy,Rossi:2020sbh,Aarrestad:2021zos,Hawks:2021ruw,Teixeira:2021yhl,Hong:2021snb,DiGuglielmo:2021ide,Migliorini:2021fuj,Govorkova:2021utb,Elabd:2021lgo,Jwa:2019zlh,Butter:2022lkf,Khoda:2022dwz,Carlson:2022vac}
 				\\\textit{Various accelerators have been studied for fast inference that is very important for latency-limited applications like the trigger at collider experiments.}

--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ The purpose of this note is to collect references for modern machine learning as
             * [The Tracking Machine Learning challenge : Throughput phase](https://arxiv.org/abs/2105.01160)
             * [Jet Single Shot Detection](https://arxiv.org/abs/2105.05785)
             * [Ariadne: PyTorch Library for Particle Track Reconstruction Using Deep Learning](https://arxiv.org/abs/2109.08982)
+            * [Event Classification with Multi-step Machine Learning](https://arxiv.org/abs/2106.02301) [[DOI](https://doi.org/10.1051/epjconf/202125103036)]
 
         *  Hardware/firmware
 


### PR DESCRIPTION
add our proceedings about multi-step ML (vCHEP2021).

Add reference for [Event Classification with Multi-step Machine Learning](https://arxiv.org/abs/2106.02301) by Masahiko Saito, Tomoe Kishimoto, Yuya Kaneta, Taichi Itoh, Yoshiaki Umeda, Junichi Tanaka, Yutaro Iiyama, Ryu Sawada, Koji Terashi which appear in proceedings for ICHEP 2021.

```
* Add 'Event Classification with Multi-step Machine Learning' which appear
  in proceedings for ICHEP 2021.
   - c.f. https://doi.org/10.1051/epjconf/202125103036
```