### PR TITLE
fix bib entry position - arxiv says july, month june

### DIFF
--- a/HEPML.bib
+++ b/HEPML.bib
@@ -438,15 +438,6 @@
     year = "2023"
 }
 
-@article{Santos:2023mib,
-    author = "Santos, Emanuel P. and Pugina, Roberta S. and Hil\'ario, Elo\'\i{}sa G. and Carvalho, Alyson J. A. and Jacinto, Carlos and Rego-Filho, Francisco A. M. G. and Canabarro, Askery and Gomes, Anderson S. L. and Caiut, Jos\'e Maur\'\i{}cio A. and Moura, Andr\'e L.",
-    title = "{Towards accurate real-time luminescence thermometry: an automated machine learning approach}",
-    eprint = "2307.05497",
-    archivePrefix = "arXiv",
-    primaryClass = "physics.ins-det",
-    month = "6",
-    year = "2023"
-}
 
 % Jul. 12, 2023
 @article{Forestano:2023ijh,
@@ -686,6 +677,16 @@
     eprint = "2306.12955",
     archivePrefix = "arXiv",
     primaryClass = "hep-ex",
+    month = "6",
+    year = "2023"
+}
+
+@article{Santos:2023mib,
+    author = "Santos, Emanuel P. and Pugina, Roberta S. and Hil\'ario, Elo\'\i{}sa G. and Carvalho, Alyson J. A. and Jacinto, Carlos and Rego-Filho, Francisco A. M. G. and Canabarro, Askery and Gomes, Anderson S. L. and Caiut, Jos\'e Maur\'\i{}cio A. and Moura, Andr\'e L.",
+    title = "{Towards accurate real-time luminescence thermometry: an automated machine learning approach}",
+    eprint = "2307.05497",
+    archivePrefix = "arXiv",
+    primaryClass = "physics.ins-det",
     month = "6",
     year = "2023"
 }

--- a/docs/recent.md
+++ b/docs/recent.md
@@ -53,11 +53,6 @@ This is an automatically compiled list of papers which have been added to the li
 * [Artificial Intelligence for the Electron Ion Collider (AI4EIC)](https://arxiv.org/abs/2307.08593)
 * [Improved selective background Monte Carlo simulation at Belle II with graph attention networks and weighted events](https://arxiv.org/abs/2307.06434)
 * [Towards an integrated determination of proton, deuteron and nuclear PDFs](https://arxiv.org/abs/2307.05967)
-
-## June 2023
-* [Towards accurate real-time luminescence thermometry: an automated machine learning approach](https://arxiv.org/abs/2307.05497)
-
-## July 2023
 * [Accelerated Discovery of Machine-Learned Symmetries: Deriving the Exceptional Lie Groups G2, F4 and E6](https://arxiv.org/abs/2307.04891)
 * [Fast Neural Network Inference on FPGAs for Triggering on Long-Lived Particles at Colliders](https://arxiv.org/abs/2307.05152)
 * [Precise Image Generation on Current Noisy Quantum Computing Devices](https://arxiv.org/abs/2307.05253)
@@ -81,6 +76,7 @@ This is an automatically compiled list of papers which have been added to the li
 * [Machine Learning methods for simulating particle response in the Zero Degree Calorimeter at the ALICE experiment, CERN](https://arxiv.org/abs/2306.13606)
 * [Retrieval of Boost Invariant Symbolic Observables via Feature Importance](https://arxiv.org/abs/2306.13496)
 * [Triggering Dark Showers with Conditional Dual Auto-Encoders](https://arxiv.org/abs/2306.12955)
+* [Towards accurate real-time luminescence thermometry: an automated machine learning approach](https://arxiv.org/abs/2307.05497)
 * [Analysis of a Skyrme energy density functional with deep learning](https://arxiv.org/abs/2306.11314)
 * [Constraining the Woods-Saxon potential in fusion reactions based on a physics-informed neural network](https://arxiv.org/abs/2306.11236)
 * [Hierarchical Neural Simulation-Based Inference Over Event Ensembles](https://arxiv.org/abs/2306.12584)


### PR DESCRIPTION
Currently on recent.md we have July, June, July due to an entry out of place based on the month key (though the arxiv month differs).